### PR TITLE
Fix reference to renamed overrideEngine function

### DIFF
--- a/public/js/visual-editor.js
+++ b/public/js/visual-editor.js
@@ -26,7 +26,7 @@ class VisualEditor {
         await this.waitForDynSections();
         await sectionSorter.init();
         await overrideEngine.load();
-        overrideEngine.applyAll();
+        overrideEngine.applyAllOverrides();
         try {
             const { isAdmin } = await apiService.checkAdminStatus();
             if (isAdmin) this.enable();


### PR DESCRIPTION
## Summary
- correct call to `overrideEngine.applyAllOverrides` in visual-editor

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686293229e3c8321a78af988de002585